### PR TITLE
Fix parseName bug and add regression test

### DIFF
--- a/packages/core/event.test.ts
+++ b/packages/core/event.test.ts
@@ -60,6 +60,33 @@ describe("event tests", () => {
       ]);
     });
 
+    it("should fall back to Nameless when attendeeName object is invalid", () => {
+      const tFunc = vi.fn(() => "foo");
+
+      const result = event.getEventName({
+        attendeeName: { foo: "bar" } as unknown as { firstName: string },
+        eventType: "example event type",
+        host: "example host",
+        eventDuration: 15,
+        t: tFunc as TFunction,
+      });
+
+      expect(result).toBe("foo");
+
+      const lastCall = tFunc.mock.lastCall;
+      expect(lastCall).toEqual([
+        "event_between_users",
+        {
+          eventName: "example event type",
+          host: "example host",
+          attendeeName: "Nameless",
+          interpolation: {
+            escapeValue: false,
+          },
+        },
+      ]);
+    });
+
     it("should return event name if no vars used", () => {
       const tFunc = vi.fn(() => "foo");
 

--- a/packages/core/event.ts
+++ b/packages/core/event.ts
@@ -11,9 +11,14 @@ export const nameObjectSchema = z.object({
 
 function parseName(name: z.infer<typeof nameObjectSchema> | string | undefined) {
   if (typeof name === "string") return name;
-  else if (typeof name === "object" && nameObjectSchema.parse(name))
-    return `${name.firstName} ${name.lastName}`.trim();
-  else return "Nameless";
+  else if (typeof name === "object") {
+    const parsed = nameObjectSchema.safeParse(name);
+    if (parsed.success) {
+      const { firstName, lastName } = parsed.data;
+      return `${firstName} ${lastName ?? ""}`.trim();
+    }
+  }
+  return "Nameless";
 }
 
 export type EventNameObjectType = {


### PR DESCRIPTION
## Summary
- fix `parseName` to avoid throwing on invalid objects
- add regression test for invalid attendee name

## Testing
- `yarn test packages/core/event.test.ts` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_683f66e457a483269d5b7e8c4363b67d