### PR TITLE
Fix typo in API next.config.js

### DIFF
--- a/apps/api/v1/next.config.js
+++ b/apps/api/v1/next.config.js
@@ -47,7 +47,7 @@ const nextConfig = {
   async rewrites() {
     return {
       afterFiles: [
-        // This redirects requests recieved at / the root to the /api/ folder.
+        // This redirects requests received at / the root to the /api/ folder.
         {
           source: "/v:version/:rest*",
           destination: "/api/v:version/:rest*",


### PR DESCRIPTION
## Summary
- fix typo in apps/api/v1/next.config.js

## Testing
- `yarn lint apps/api/v1/next.config.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f692f868c8326844f329f32008a3f