### PR TITLE
Add marketplace appointment models and basic API

### DIFF
--- a/apps/web/pages/api/bookings/index.ts
+++ b/apps/web/pages/api/bookings/index.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+import { allocateStaff } from '@calcom/event-types';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  if (req.method === 'POST') {
+    const { serviceId, preferredStart } = req.body;
+    const staff = await allocateStaff(serviceId, new Date(preferredStart));
+    const service = await prisma.service.findUnique({ where: { id: serviceId } });
+    if (!service) return res.status(404).end();
+    const end = new Date(new Date(preferredStart).getTime() + service.durationMin * 60000);
+    const booking = await prisma.booking.create({
+      data: {
+        serviceId,
+        staffId: staff?.id ?? null,
+        vendorId: service.vendorId,
+        startTime: new Date(preferredStart),
+        endTime: end,
+        title: service.name,
+      },
+    });
+    return booking;
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/marketplaces/[id]/activate.ts
+++ b/apps/web/pages/api/marketplaces/[id]/activate.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import prisma from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session) return res.status(401).end();
+  if (req.method === 'PATCH') {
+    const { id } = req.query;
+    const marketplace = await prisma.marketplace.update({ where: { id: id as string }, data: { status: 'active' } });
+    return marketplace;
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/marketplaces/index.ts
+++ b/apps/web/pages/api/marketplaces/index.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import prisma from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session) return res.status(401).end();
+  if (req.method === 'POST') {
+    const marketplace = await prisma.marketplace.create({ data: { name: req.body.name, status: 'draft' } });
+    return marketplace;
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/services/[id].ts
+++ b/apps/web/pages/api/services/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  const { id } = req.query;
+  if (req.method === 'GET') {
+    return prisma.service.findUnique({ where: { id: id as string } });
+  }
+  if (req.method === 'PATCH') {
+    return prisma.service.update({ where: { id: id as string }, data: req.body });
+  }
+  if (req.method === 'DELETE') {
+    await prisma.service.delete({ where: { id: id as string } });
+    return { id };
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/services/index.ts
+++ b/apps/web/pages/api/services/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  if (req.method === 'GET') {
+    return prisma.service.findMany();
+  }
+  if (req.method === 'POST') {
+    return prisma.service.create({ data: { ...req.body, vendorId: session.vendorId! } });
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/staff/[id].ts
+++ b/apps/web/pages/api/staff/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  const { id } = req.query;
+  if (req.method === 'GET') {
+    return prisma.staff.findUnique({ where: { id: id as string } });
+  }
+  if (req.method === 'PATCH') {
+    return prisma.staff.update({ where: { id: id as string }, data: req.body });
+  }
+  if (req.method === 'DELETE') {
+    await prisma.staff.delete({ where: { id: id as string } });
+    return { id };
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/staff/index.ts
+++ b/apps/web/pages/api/staff/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  if (req.method === 'GET') {
+    return prisma.staff.findMany();
+  }
+  if (req.method === 'POST') {
+    return prisma.staff.create({ data: { ...req.body, vendorId: session.vendorId!, teamId: req.body.teamId } });
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/vendors/[id].ts
+++ b/apps/web/pages/api/vendors/[id].ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  const { id } = req.query;
+  if (req.method === 'GET') {
+    return prisma.vendor.findUnique({ where: { id: id as string } });
+  }
+  if (req.method === 'PATCH') {
+    return prisma.vendor.update({ where: { id: id as string }, data: req.body });
+  }
+  if (req.method === 'DELETE') {
+    await prisma.vendor.delete({ where: { id: id as string } });
+    return { id };
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/pages/api/vendors/index.ts
+++ b/apps/web/pages/api/vendors/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getServerSession } from '@calcom/features/auth/lib/getServerSession';
+import { getPrismaForMarketplace } from '@calcom/prisma';
+import { defaultResponder } from '@calcom/lib/server';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession({ req, res });
+  if (!session?.marketplaceId) return res.status(401).end();
+  const prisma = getPrismaForMarketplace(session.marketplaceId);
+  if (req.method === 'GET') {
+    return prisma.vendor.findMany();
+  }
+  if (req.method === 'POST') {
+    return prisma.vendor.create({ data: { name: req.body.name, timezone: req.body.timezone, openHoursJson: req.body.openHoursJson, marketplaceId: session.marketplaceId } });
+  }
+  res.status(405).end();
+}
+
+export default defaultResponder(handler);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,7 +10,8 @@
       "@server/*": ["server/*"],
       "@prisma/client/*": ["@calcom/prisma/client/*"],
       "@calcom/repository/*": ["@calcom/lib/server/repository/*"],
-      "@calcom/ui/*": ["../../packages/ui/components/*"]
+      "@calcom/ui/*": ["../../packages/ui/components/*"],
+      "@calcom/event-types": ["../../packages/@calcom/event-types"]
     },
     "plugins": [
       {

--- a/packages/@calcom/event-types/index.ts
+++ b/packages/@calcom/event-types/index.ts
@@ -1,0 +1,50 @@
+import prisma from '@calcom/prisma';
+
+async function countBookingsThisWeek(staffId: string) {
+  const now = new Date();
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() - now.getDay());
+  return prisma.booking.count({
+    where: {
+      staffId,
+      startTime: { gte: startOfWeek },
+      status: 'ACCEPTED',
+    },
+  });
+}
+
+function isWorkingThatDay(start: Date) {
+  return true;
+}
+
+function hasNoOverlap(start: Date, duration: number, staffId: string) {
+  return prisma.booking.count({
+    where: {
+      staffId,
+      startTime: { lte: start },
+      endTime: { gte: start },
+    },
+  }).then((c) => c === 0);
+}
+
+export async function allocateStaff(serviceId: string, start: Date) {
+  const service = await prisma.service.findUnique({ where: { id: serviceId } });
+  if (!service) return null;
+  const eligible = await prisma.staff.findMany({
+    where: {
+      vendorId: service.vendorId,
+      skills: { some: { id: service.requiredSkillId } },
+    },
+    select: { id: true },
+  });
+  const results = [] as { id: string; weeklyCount: number }[];
+  for (const e of eligible) {
+    const working = isWorkingThatDay(start);
+    const noOverlap = await hasNoOverlap(start, service.durationMin, e.id);
+    if (!working || !noOverlap) continue;
+    const weeklyCount = await countBookingsThisWeek(e.id);
+    results.push({ id: e.id, weeklyCount });
+  }
+  results.sort((a,b)=>a.weeklyCount-b.weeklyCount || a.id.localeCompare(b.id));
+  return results[0] ?? null;
+}

--- a/packages/@calcom/event-types/package.json
+++ b/packages/@calcom/event-types/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@calcom/event-types",
+  "version": "0.0.0",
+  "main": "index.ts",
+  "types": "index.ts",
+  "private": true,
+  "dependencies": {
+    "@calcom/prisma": "*"
+  }
+}

--- a/packages/features/auth/lib/getServerSession.ts
+++ b/packages/features/auth/lib/getServerSession.ts
@@ -105,6 +105,8 @@ export async function getServerSession(options: {
     },
     profileId: token.profileId,
     upId,
+    marketplaceId: (token as any).marketplaceId ?? null,
+    vendorId: (token as any).vendorId ?? null,
   };
 
   if (token?.impersonatedBy?.id) {

--- a/packages/features/auth/lib/next-auth-options.ts
+++ b/packages/features/auth/lib/next-auth-options.ts
@@ -489,6 +489,8 @@ export const getOptions = ({
           name: session?.name ?? token.name,
           username: session?.username ?? token.username,
           email: session?.email ?? token.email,
+          marketplaceId: (session as any)?.marketplaceId ?? (token as any).marketplaceId ?? null,
+          vendorId: (session as any)?.vendorId ?? (token as any).vendorId ?? null,
         } as JWT;
       }
       const autoMergeIdentities = async () => {
@@ -554,6 +556,8 @@ export const getOptions = ({
           profileId: profile.id,
           upId,
           belongsToActiveTeam,
+          marketplaceId: (token as any).marketplaceId ?? null,
+          vendorId: (token as any).vendorId ?? null,
           // All organizations in the token would be too big to store. It breaks the sessions request.
           // So, we just set the currently switched organization only here.
           // platform org user don't need profiles nor domains
@@ -596,6 +600,8 @@ export const getOptions = ({
           locale: user?.locale,
           profileId: user.profile?.id ?? token.profileId ?? null,
           upId: user.profile?.upId ?? token.upId ?? null,
+          marketplaceId: (token as any).marketplaceId ?? null,
+          vendorId: (token as any).vendorId ?? null,
         } as JWT;
       }
 
@@ -710,6 +716,8 @@ export const getOptions = ({
         ...session,
         profileId,
         upId: token.upId || session.upId,
+        marketplaceId: (token as any).marketplaceId ?? null,
+        vendorId: (token as any).vendorId ?? null,
         hasValidLicense,
         user: {
           ...session.user,

--- a/packages/prisma/index.ts
+++ b/packages/prisma/index.ts
@@ -7,7 +7,7 @@ import { disallowUndefinedDeleteUpdateManyExtension } from "./extensions/disallo
 import { excludeLockedUsersExtension } from "./extensions/exclude-locked-users";
 import { excludePendingPaymentsExtension } from "./extensions/exclude-pending-payment-teams";
 import { usageTrackingExtention } from "./extensions/usage-tracking";
-import { bookingReferenceMiddleware } from "./middleware";
+import { bookingReferenceMiddleware, marketplaceMiddleware } from "./middleware";
 
 const prismaOptions: Prisma.PrismaClientOptions = {};
 
@@ -73,6 +73,12 @@ export const readonlyPrisma = process.env.INSIGHTS_DATABASE_URL
       datasources: { db: { url: process.env.INSIGHTS_DATABASE_URL } },
     })
   : prisma;
+
+export function getPrismaForMarketplace(marketplaceId: string) {
+  const client = customPrisma();
+  marketplaceMiddleware(client, marketplaceId);
+  return client;
+}
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prismaWithoutClientExtensions = prismaWithoutClientExtensions;

--- a/packages/prisma/middleware/index.ts
+++ b/packages/prisma/middleware/index.ts
@@ -1,1 +1,2 @@
 export { default as bookingReferenceMiddleware } from "./bookingReference";
+export { default as marketplaceMiddleware } from "./marketplace";

--- a/packages/prisma/middleware/marketplace.ts
+++ b/packages/prisma/middleware/marketplace.ts
@@ -1,0 +1,12 @@
+import type { PrismaClient } from "@prisma/client";
+
+export default function marketplaceMiddleware(prisma: PrismaClient, marketplaceId: string) {
+  prisma.$use(async (params, next) => {
+    if (marketplaceId) {
+      await prisma.$executeRawUnsafe(
+        `SELECT set_config('app.current_marketplace', '${marketplaceId}', true)`
+      );
+    }
+    return next(params);
+  });
+}

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -668,6 +668,12 @@ model Booking {
   // Ah, made a typo here. Should have been routedFromRoutingFormRe"s"ponse. Live with it :(
   routedFromRoutingFormReponse App_RoutingForms_FormResponse?
   assignmentReason             AssignmentReason[]
+  vendor                       Vendor?   @relation(fields: [vendorId], references: [id])
+  vendorId                     String?
+  staff                        Staff?    @relation(fields: [staffId], references: [id])
+  staffId                      String?
+  service                      Service?  @relation(fields: [serviceId], references: [id])
+  serviceId                    String?
 
   @@index([eventTypeId])
   @@index([userId])
@@ -675,6 +681,7 @@ model Booking {
   @@index([recurringEventId])
   @@index([uid])
   @@index([status])
+  @@index([vendorId])
   @@index([startTime, endTime, status])
 }
 
@@ -1823,4 +1830,91 @@ model App_RoutingForms_IncompleteBookingActions {
   data         Json
   enabled      Boolean                     @default(true)
   credentialId Int?
+}
+
+enum MarketplaceStatus {
+  draft
+  active
+}
+
+model Marketplace {
+  id        String   @id @default(uuid())
+  name      String
+  status    MarketplaceStatus @default(draft)
+  createdAt DateTime @default(now())
+  vendors   Vendor[]
+}
+
+model Vendor {
+  id            String      @id @default(uuid())
+  marketplace   Marketplace @relation(fields: [marketplaceId], references: [id])
+  marketplaceId String
+  name          String
+  timezone      String
+  openHoursJson Json?
+  teams         Team[]
+  services      Service[]
+  staff         Staff[]
+  ledgerEntries LedgerEntry[]
+
+  @@index([marketplaceId])
+}
+
+model Team {
+  id       String @id @default(uuid())
+  vendor   Vendor @relation(fields: [vendorId], references: [id])
+  vendorId String
+  name     String
+  services Service[]
+  staff    Staff[]
+}
+
+model Skill {
+  id   String @id @default(uuid())
+  code String @unique
+  staff Staff[]
+  services Service[]
+}
+
+model Staff {
+  id            String   @id @default(uuid())
+  vendor        Vendor   @relation(fields: [vendorId], references: [id])
+  vendorId      String
+  name          String
+  skills        Skill[]
+  workingDays   Int[]
+  workingHours  Json?
+  lunchStart    DateTime?
+  lunchDuration Int?
+  bookings      Booking[]
+  team          Team?    @relation(fields: [teamId], references: [id])
+  teamId        String?
+
+  @@index([vendorId])
+}
+
+model Service {
+  id             String  @id @default(uuid())
+  vendor         Vendor  @relation(fields: [vendorId], references: [id])
+  vendorId       String
+  team           Team    @relation(fields: [teamId], references: [id])
+  teamId         String
+  name           String
+  durationMin    Int
+  requiredSkill  Skill   @relation(fields: [requiredSkillId], references: [id])
+  requiredSkillId String
+  bookings       Booking[]
+
+  @@index([vendorId])
+}
+
+model LedgerEntry {
+  id        String   @id @default(uuid())
+  booking   Booking  @relation(fields: [bookingId], references: [id])
+  bookingId Int
+  vendor    Vendor   @relation(fields: [vendorId], references: [id])
+  vendorId  String
+  amount    Int
+  feeAmount Int
+  createdAt DateTime @default(now())
 }

--- a/packages/types/next-auth.d.ts
+++ b/packages/types/next-auth.d.ts
@@ -14,6 +14,8 @@ declare module "next-auth" {
     profileId?: number | null;
     upId: string;
     user: User;
+    marketplaceId?: string | null;
+    vendorId?: string | null;
   }
 
   interface User extends Omit<DefaultUser, "id"> {
@@ -68,5 +70,7 @@ declare module "next-auth/jwt" {
     };
     organizationId?: number | null;
     locale?: string;
+    marketplaceId?: string | null;
+    vendorId?: string | null;
   }
 }


### PR DESCRIPTION
## Summary
- extend Prisma schema for multi-marketplace vendors and services
- add marketplace-aware NextAuth session claims
- provide helper to scope Prisma by marketplace
- implement marketplace CRUD and booking APIs
- include placeholder staff allocator

## Testing
- `yarn prisma generate` *(fails: network access required)*
- `yarn lint` *(fails: network access required)*
- `yarn test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_683f6797b5348326badc8adb40d5dd50